### PR TITLE
Fix Completion due to mismatch in executable name

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ all: build
 
 build:
 	@mkdir -p bin/
-	go build -o $(OUTPUT_DIR)/qcow2util cmd/main.go
+	go build -o $(OUTPUT_DIR)/qcow2_util cmd/main.go
 
 fmt:
 	gofmt -w ./qcow2 ./cmd 


### PR DESCRIPTION
This commit changes the name of the executable generated from Makefile to match the name of the `cobra` project to make sure shell completion work as expected

fixes #10