### PR TITLE
Update executable name in Docs and Test script to align with PR #11

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,9 +45,9 @@ Qcow2 Utility
 ==============
 ```shell
 make 
-bin/qcow2util create <-f filename> <-s filesize> [-b backingfile] [-d datafile] [--enable-subcluster]
-bin/qcow2util info <-f filename> [--detail] [--pretty] 
-bin/qcow2util dd <-i inputfile> [-f inputformat] <-o outputfile> <-O outputformat> [--l2-cache-size=size]
+bin/qcow2_util create <-f filename> <-s filesize> [-b backingfile] [-d datafile] [--enable-subcluster]
+bin/qcow2_util info <-f filename> [--detail] [--pretty] 
+bin/qcow2_util dd <-i inputfile> [-f inputformat] <-o outputfile> <-O outputformat> [--l2-cache-size=size]
 ```
 
 License 

--- a/test.sh
+++ b/test.sh
@@ -23,10 +23,10 @@ echo "======== Test raw2qcow and qcow2raw ==========="
 time dd if=/dev/random of=$SRC_FILE bs=$BS count=$COUNT
 sleep 1
 
-time bin/qcow2util dd -i $SRC_FILE -o $QCOW2_FILE -O qcow2 -f raw
+time bin/qcow2_util dd -i $SRC_FILE -o $QCOW2_FILE -O qcow2 -f raw
 sleep 1
 #exit
-time bin/qcow2util dd -o $DST_FILE -i $QCOW2_FILE -O raw -f qcow2
+time bin/qcow2_util dd -o $DST_FILE -i $QCOW2_FILE -O raw -f qcow2
 sleep 1
 
 CK_SRC=`cksum $SRC_FILE | awk '{print $1}'`
@@ -40,7 +40,7 @@ fi
 
 echo "======== Test qcow2qcow  ==========="
 
-time bin/qcow2util dd -i $QCOW2_FILE -o $QCOW2_MIRROR_FILE  -O qcow2
+time bin/qcow2_util dd -i $QCOW2_FILE -o $QCOW2_MIRROR_FILE  -O qcow2
 sleep 1
 
 CK_SRC=`cksum $QCOW2_FILE | awk '{print $1}'`
@@ -54,7 +54,7 @@ fi
 
 echo "======== Test raw2raw  ==========="
 
-time bin/qcow2util dd -i $SRC_FILE -o $SRC_MIRROR_FILE  -O raw
+time bin/qcow2_util dd -i $SRC_FILE -o $SRC_MIRROR_FILE  -O raw
 sleep 1
 
 CK_SRC=`cksum $SRC_FILE | awk '{print $1}'`


### PR DESCRIPTION
This commit ensures executable name in the `README.md` and `test.sh` is updated according to the changes introduced in PR #11.